### PR TITLE
Catch and print exceptions while processing a file

### DIFF
--- a/kanjivg2svg.rb
+++ b/kanjivg2svg.rb
@@ -182,7 +182,13 @@ processed = 0
 puts "Starting the conversion @ #{Time.now} ..."
 
 Dir["#{input_dir}*.svg"].each do |file|
-  Importer::KanjiVG.new(File.open(file), output_dir, type.to_sym)
+  begin
+    Importer::KanjiVG.new(File.open(file), output_dir, type.to_sym)
+  rescue => e
+    puts "Failed to process file: #{file}"
+    puts "\t" << e.message
+    e.backtrace.each { |msg| puts "\t" << msg }
+  end
   processed += 1
   if processed % 200 == 0
     puts "Processed #{processed} @ #{Time.now}"


### PR DESCRIPTION
It is useful to catch the exceptions happened while processing a file so that the generation can continue.
Example result:

```
Starting the conversion @ 2015-12-26 00:05:04 +0100 ...
[...process some files...]
Failed to process file: k/09234-Insatsu.svg
    undefined method `[]' for nil:NilClass
    kanjivg2svg.rb:109:in `block in parse'
    /var/lib/gems/1.9.1/gems/nokogiri-1.6.6.2/lib/nokogiri/xml/node_set.rb:187:in `block in each'
    /var/lib/gems/1.9.1/gems/nokogiri-1.6.6.2/lib/nokogiri/xml/node_set.rb:186:in `upto'
    /var/lib/gems/1.9.1/gems/nokogiri-1.6.6.2/lib/nokogiri/xml/node_set.rb:186:in `each'
    kanjivg2svg.rb:94:in `parse'
    kanjivg2svg.rb:39:in `initialize'
    kanjivg2svg.rb:186:in `new'
    kanjivg2svg.rb:186:in `block in <main>'
    kanjivg2svg.rb:184:in `each'
    kanjivg2svg.rb:184:in `<main>'
[...process some files...]
```
