### PR TITLE
Generate also for SVGs not including kvg:element

### DIFF
--- a/kanjivg2svg.rb
+++ b/kanjivg2svg.rb
@@ -49,10 +49,14 @@ class Importer
     private
 
     def parse(doc)
+      codepoint = nil
       entry = doc.css('g')[1]
-      return if entry['kvg:element'].nil?
+      if entry['kvg:element'].nil?
+        codepoint = entry['id'].split(':')[1].to_i(16) # get it from the id="kvg:0abcd"
+      else
+        codepoint = entry['kvg:element'].codepoints.first
+      end
 
-      codepoint = entry['kvg:element'].codepoints.first
       svg = File.open("#{@output_dir}/#{codepoint}_#{@type}.svg", File::RDWR|File::TRUNC|File::CREAT)
       stroke_count = 0
       stroke_total = entry.css('path[d]').length


### PR DESCRIPTION
The symbol identifier in SVGs not including the attribute `kvg:element` (for example: kanas) can be obtained from the attribute `id`.
